### PR TITLE
Make pages full screen height

### DIFF
--- a/src/components/layout/layout.tsx
+++ b/src/components/layout/layout.tsx
@@ -14,7 +14,7 @@ type Props = {
  */
 export const Layout: React.FC<Props> = ({ blogPost, children }) => (
   <div
-    className={`overflow-x-hidden max-w-[100vw] text-slate-600 dark:text-slate-200 ${
+    className={`overflow-x-hidden max-w-[100vw] text-slate-600 dark:text-slate-200 min-h-screen ${
       blogPost ? 'bg-slate-100 dark:bg-slate-900' : 'bg-white dark:bg-slate-800'
     }`}
   >

--- a/src/hooks/useHasMounted.tsx
+++ b/src/hooks/useHasMounted.tsx
@@ -50,8 +50,8 @@ export const useHasMounted = (): boolean => {
  *   <StatefulComponent />
  * </ClientOnly>
  */
-export const ClientOnly: React.FC = ({ children, ...delegated }) => {
+export const ClientOnly: React.FC = ({ children }) => {
   const hasMounted = useHasMounted();
   if (!hasMounted) return null;
-  return <div {...delegated}>{children}</div>;
+  return <>{children}</>;
 };


### PR DESCRIPTION
Ensure that pages always take up full screen height, to avoid white space at bottom of the page (especially problematic in dark theme, where the white space is actually white, and clashes with the theme color).

Opted to solve this by making the page layout wrapper have `min-height: 100vh`, and adding the extra space to the bottom of the page, so the white space at the bottom is themed correctly.

Could have alternatively used grid to stretch the main content. Decided against this, since the main content has fairly complex markup which would require a lot of hack-y styling changes to work correctly. Also, on very small pages (like 404), this would result in large empty areas in the middle of the page.