### PR TITLE
Fix image corners on Safari

### DIFF
--- a/src/components/blog-card.tsx
+++ b/src/components/blog-card.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 export const BlogCard: React.FC<Props> = ({ item }) => {
   return (
-    <article className="shadow-lg rounded-xl overflow-hidden bg-white dark:bg-slate-700 flex flex-col md:flex-row lg:flex-col w-full max-w-[325px] md:max-w-full lg:max-w-[325px] mx-auto text-slate-600 dark:text-slate-200">
+    <article className="shadow-lg rounded-xl overflow-hidden bg-white dark:bg-slate-700 flex flex-col md:flex-row lg:flex-col w-full max-w-[325px] md:max-w-full lg:max-w-[325px] mx-auto text-slate-600 dark:text-slate-200 isolate">
       {/* image wrap */}
       {item.frontmatter.featured_image && (
         <div className="md:flex-[3] lg:flex-auto overflow-hidden">

--- a/src/components/portfolio-card.tsx
+++ b/src/components/portfolio-card.tsx
@@ -37,7 +37,7 @@ export const PortfolioCard: React.FC<PCardProps> = ({ item, reversed }) => {
       {/* preview image wrapper */}
       <div
         className={clsx(
-          'row-start-1 row-end-3 md:row-span-full select-none pointer-events-none rounded-xl',
+          'row-start-1 row-end-3 md:row-span-full select-none pointer-events-none',
           reversed
             ? 'col-span-full md:col-start-6 md:col-end-13'
             : 'col-span-full md:col-start-1 md:col-end-8'
@@ -47,7 +47,7 @@ export const PortfolioCard: React.FC<PCardProps> = ({ item, reversed }) => {
           <GatsbyImage
             image={image}
             alt={`Picture of ${title}`}
-            className="w-full h-full select-none pointer-events-none rounded-xl shadow-xl"
+            className="w-full h-full select-none pointer-events-none shadow-xl rounded-xl overflow-hidden isolate"
             imgClassName="w-full h-full object-cover select-none pointer-events-none"
           />
         )}


### PR DESCRIPTION
Prevent image corners from breaking out of their containers with border radius.

The issue was solved it by setting `isolation: isolate;` on the container to create a new stacking context.

Resolves #40